### PR TITLE
change README.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Rong Li
 301308325
 
 
-  In this assignment, provided pseudo cod is used to implement backward chanining algorithm. Each rules are implemented as an object in order to separate the "head" and the "body" of each statements. The main part of the code was divided the object into two parts: when a solution was found or when it couldn't. Users were provided with options to insert queries. The program is capable of showing the wrong path before finding the correct path.
+  In this assignment, provided pseudo code is used to implement backward chaining algorithm. Each rule are implemented as an object in order to separate the "head" and the "body" of each statement. The main part of the code is dividing the object into two parts: when a solution was found or when it couldn't. Users were provided with options to insert queries. The program is capable of showing the wrong path before finding the correct path.
 
 Limitation:
 The program couldn't print different searched trials of path in the scenario of no solution. Problems can only be done in the scenario of a solution was found. When there was no solution, the program can only print the whole path it searched.


### PR DESCRIPTION
1. Typo: "pseudo cod" changes to "pseudo code", "chanining" changes to "chaining". 
2. Grammar: "each rules" and "each statements" should use singular. Changing to "each rule" and "each statement".
3. "The main part of the code was divided the object into two parts" this sentence should not be a passive voice otherwise meaningless. This sentence should in an active voice " The main part of the code is dividing the object into two parts".
Fixes #5 